### PR TITLE
Avoid exceptions in InboundEmail.php for date headers with extra trailing characters #5297

### DIFF
--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -5325,10 +5325,12 @@ class InboundEmail extends SugarBean
 
                 $possibleFormats = [
                     \DateTime::RFC2822,
+		    \DateTime::RFC2822 . '+', // ignore remaining characters after valid RFC2822 date header
                     str_replace(['D, '], '', \DateTime::RFC2822), // day-of-week is optional
                     str_replace([':s'], '', \DateTime::RFC2822), // seconds are optional
                     str_replace(['D, ', ':s'], '', \DateTime::RFC2822), // day-of-week is optional, seconds are optional
                     \DateTime::RFC822,
+		    \DateTime::RFC822 . '+', // ignore remaining characters after valid RFC822 date header
                     str_replace(['D, '], '', \DateTime::RFC822), // day is optional
                     str_replace([':s'], '', \DateTime::RFC822), // seconds are optional
                     str_replace(['D, ', ':s'], '', \DateTime::RFC822), // day is optional, seconds are optional


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added an extra line for both 822 and 2822 possibleFormats, both with a trailing '+' character that will lead to ignoring extra characters behind an otherwise compliant RFC2822/822 date header. 
## Description
<!--- Describe your changes in detail -->
To make the code clearer and differentiate, I have added an extra pattern with the trailing '+'. The trailing '+'  could also be added to the original pattern ("\DateTmie:RFC2822") above, avoding the extra line(s). 
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
https://github.com/salesagility/SuiteCRM/issues/5297
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A date header like "Fri, 23 Feb 2018 16:29:06 +0100 (CET)" (this format is generated by several MTAs, including Zimbra in our case) would lead to an exception: Exception in Controller: Expected header Date to comply with RFC882 or RFC2882, but actual is "Fri, 23 Feb 2018 16:29:06 +0100 (CET)"
## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->