### PR TITLE
Fix for #5297 - ignore extra trailing characters

### DIFF
--- a/modules/InboundEmail/InboundEmail.php
+++ b/modules/InboundEmail/InboundEmail.php
@@ -5325,10 +5325,12 @@ class InboundEmail extends SugarBean
 
                 $possibleFormats = [
                     \DateTime::RFC2822,
+		    \DateTime::RFC2822 . '+', // ignore trailing characters after a RFC2822 compliant date header
                     str_replace(['D, '], '', \DateTime::RFC2822), // day-of-week is optional
                     str_replace([':s'], '', \DateTime::RFC2822), // seconds are optional
                     str_replace(['D, ', ':s'], '', \DateTime::RFC2822), // day-of-week is optional, seconds are optional
                     \DateTime::RFC822,
+                    \DateTime::RFC822 . '+', // ignore trailing characters after a RFC822 compliant date heade
                     str_replace(['D, '], '', \DateTime::RFC822), // day is optional
                     str_replace([':s'], '', \DateTime::RFC822), // seconds are optional
                     str_replace(['D, ', ':s'], '', \DateTime::RFC822), // day is optional, seconds are optional


### PR DESCRIPTION
Adding more tolerance to $possibleFormats array

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a trailing '+' to two possibleFormats array entries to allow for trailing characters in date header
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->